### PR TITLE
Cap vercel memory size to hobby plan max

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/*.js": {
-      "memory": 1200,
+      "memory": 1024,
       "maxDuration": 10
     }
   },


### PR DESCRIPTION
Fixes vercel deploy issue caused by cherry-pick from https://github.com/anuraghazra/github-readme-stats/commit/3344bfd1501377e273b4d321323d193bd47bbf54