### PR TITLE
build: add @stats-organization/github-readme-stats-core (migration stage 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@stats-organization/github-readme-stats-core": "^2.1.5",
         "axios": "^1.19.0",
         "dotenv": "^17.4.2",
         "emoji-name-map": "^2.0.3",
@@ -3106,6 +3107,20 @@
       "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@stats-organization/github-readme-stats-core": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@stats-organization/github-readme-stats-core/-/github-readme-stats-core-2.1.5.tgz",
+      "integrity": "sha512-LkOGpvD9XOP3MK0kOX3tFOW0WJa8tJweM6/ISsdd16AXipv2idk754y7GtDeYVQfBFjT9jpcCeiJiznEVl23NA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.18.1",
+        "emoji-name-map": "^2.0.3",
+        "github-username-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": "24.x"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "wrangler": "^4.118.0"
   },
   "dependencies": {
+    "@stats-organization/github-readme-stats-core": "^2.1.5",
     "axios": "^1.19.0",
     "dotenv": "^17.4.2",
     "emoji-name-map": "^2.0.3",


### PR DESCRIPTION
Stage 2 of #826.

Adds the upstream core package alongside the existing `src/` tree. Purely additive — no source files touched, no behavioral change. Both implementations coexist until stage 4 flips routes one endpoint at a time.

### Changes
- `package.json`: `@stats-organization/github-readme-stats-core@^2.1.5`
- `package-lock.json`: +15 lines, one package, **no new transitive deps** — core's deps (axios, emoji-name-map, github-username-regex) were already satisfied

### Verification
Package resolves under Node with 15 exports; `api`, `gist`, `pin`, `topLangs`, `wakatime`, `loadConfigFromEnv`, `renderError` are functions and `themes` is an object.

Test suite not run — no source changed.

### Not covered here
Whether wrangler bundles the package for the Workers runtime, and whether axios works there. Both are stage 3.

Refs #826