### PR TITLE
feat(cloudflare): serve /api/top-langs from upstream core (migration stage 4)

### DIFF
--- a/cloudflare/core.js
+++ b/cloudflare/core.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { loadConfigFromEnv } from "@stats-organization/github-readme-stats-core";
+
+// Core issues its GitHub requests through axios. Axios would resolve to its
+// fetch adapter here anyway, since neither the http nor the xhr adapter is
+// available under workerd, but pinning it keeps the choice explicit rather
+// than dependent on axios' adapter probing order.
+axios.defaults.adapter = "fetch";
+
+let configured = false;
+
+/**
+ * Run an upstream core card handler and write its result into the response
+ * adapter, so the shared header handling in index.js still applies.
+ *
+ * @param {Function} handler Core card handler.
+ * @param {import("./adapter.js").RequestAdapter} req Request adapter.
+ * @param {import("./adapter.js").ResponseAdapter} res Response adapter.
+ * @param {object} env Environment variables.
+ * @returns {Promise<void>}
+ */
+export const fromCore = async (handler, req, res, env) => {
+  if (!configured) {
+    // env is constant for the lifetime of a deployment, so load it once.
+    loadConfigFromEnv(env);
+    configured = true;
+  }
+
+  // The second argument is a per-user PAT, which is backed by Postgres
+  // upstream. We don't have that, so core falls back to the PAT_n pool.
+  const { content } = await handler(req.query, null);
+
+  res.setHeader("Content-Type", "image/svg+xml");
+  res.send(content);
+};

--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -1,8 +1,9 @@
+import { topLangs } from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
+import { fromCore } from "./core.js";
 import { handler as gistHandler } from "../api/gist.js";
 import { handler as indexHandler } from "../api/index.js";
 import { handler as pinHandler } from "../api/pin.js";
-import { handler as topLangsHandler } from "../api/top-langs.js";
 import wakatimeHandler from "../api/wakatime.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
 import { handler as statusUpHandler } from "../api/status/up.js";
@@ -58,7 +59,7 @@ export default {
     } else if (pathname === "/api/pin") {
       await pinHandler(req, res, env);
     } else if (pathname === "/api/top-langs") {
-      await topLangsHandler(req, res, env);
+      await fromCore(topLangs, req, res, env);
     } else if (pathname === "/api/wakatime") {
       await wakatimeHandler(req, res, env);
     } else if (pathname === "/api/status/pat-info") {


### PR DESCRIPTION
First endpoint of the stage 4 cutover in #826.

`cloudflare/core.js` adapts an upstream core handler to the existing `ResponseAdapter`, keeping the migrated branch inside the `if/else` chain so the shared header tail still applies. `RequestAdapter.query` already yields the params object core wants. The per-user PAT argument is `null` (Postgres-backed upstream), so core uses the `PAT_n` pool — same naming our retryer uses, so existing secrets carry over.

### Verified
- **Output parity**: preview deploy (`pr-828` alias, real `PAT_n`) vs production is byte-identical for `?username=<username>` plus `layout=compact`, `theme=radical&langs_count=3`, `hide=javascript&hide_border=true` and `custom_title=My%20Top%20Langs` — after normalizing the `data-testid="progress-background"` attribute core adds to progress bars. The un-decoded `%20` matches too, confirming `req.query` preserves current behaviour.
- Bundle 538.90 KiB / **130.52 KiB gzipped** (limit 1 MB) with both codebases shipping
- Adapter spike under `workerd`: `fetch` → 200, `http`/`xhr` → `ERR_NOT_SUPPORT`. Axios picks fetch unaided; the pin only makes it deterministic
- No regressions on `/api`, `/api/gist`, `/api/status/up`, `/`, `/robots.txt`; `/nope` still 404
- `eslint --max-warnings 0` on `cloudflare/**`

Error cards differ intentionally: the issue link now points at the successor project, and core XML-escapes quotes where legacy emitted them raw.

### Notes
- `x-robots-tag: noindex` on the preview URL is a Cloudflare rewrite, not a code change — legacy paths show it too on that host.
- `tests/calculateRank.test.js` fails locally on Node 26 with a 2-ULP float difference. Pre-existing, identical on base, and CI passes on Node 22.

Refs #826
