### PR TITLE
ci: bump wrangler and give PR previews a stable alias

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,4 +17,4 @@ jobs:
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: 4.15.0
+          wranglerVersion: 4.118.0

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,5 +17,5 @@ jobs:
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: 4.15.0
-          command: versions upload
+          wranglerVersion: 4.118.0
+          command: versions upload --preview-alias pr-${{ github.event.number }}


### PR DESCRIPTION
Groundwork for verifying #828 against real data before merging it.

- `preview.yml`: adds `--preview-alias pr-${{ github.event.number }}`, so each PR gets a predictable preview URL instead of a version-id-derived one that has to be read from the job log
- both workflows: pin bumped 4.15.0 → 4.118.0, matching the `^4.118.0` devDependency. `--preview-alias` needs the newer version, and CI was otherwise deploying on a build two years older than the one used locally

Preview versions receive no production traffic but inherit the Worker's secrets, so `PAT_n` are live — which is what makes real-output verification possible.

Refs #826