### PR TITLE
fix(cloudflare): guard core path, serve /api/pin from core

### DIFF
--- a/cloudflare/core.js
+++ b/cloudflare/core.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { loadConfigFromEnv } from "@stats-organization/github-readme-stats-core";
+import { guardAccess } from "../src/common/access.js";
 
 // Core issues its GitHub requests through axios. Axios would resolve to its
 // fetch adapter here anyway, since neither the http nor the xhr adapter is
@@ -7,29 +8,53 @@ import { loadConfigFromEnv } from "@stats-organization/github-readme-stats-core"
 // than dependent on axios' adapter probing order.
 axios.defaults.adapter = "fetch";
 
+// Which query parameter carries the identifier guarded for each access type.
+const ID_PARAM = {
+  username: "username",
+  gist: "id",
+  wakatime: "username",
+};
+
 let configured = false;
 
 /**
  * Run an upstream core card handler and write its result into the response
  * adapter, so the shared header handling in index.js still applies.
  *
+ * Core has no notion of our whitelist/blacklist -- upstream keeps access
+ * control in its backend rather than in the card package -- so the guard is
+ * applied here, before the handler runs.
+ *
  * @param {Function} handler Core card handler.
+ * @param {"username"|"gist"|"wakatime"} type Access type to guard on.
  * @param {import("./adapter.js").RequestAdapter} req Request adapter.
  * @param {import("./adapter.js").ResponseAdapter} res Response adapter.
  * @param {object} env Environment variables.
  * @returns {Promise<void>}
  */
-export const fromCore = async (handler, req, res, env) => {
+export const fromCore = async (handler, type, req, res, env) => {
   if (!configured) {
     // env is constant for the lifetime of a deployment, so load it once.
     loadConfigFromEnv(env);
     configured = true;
   }
 
+  res.setHeader("Content-Type", "image/svg+xml");
+
+  const { title_color, text_color, bg_color, border_color, theme } = req.query;
+  const access = guardAccess({
+    res,
+    id: req.query[ID_PARAM[type]],
+    type,
+    colors: { title_color, text_color, bg_color, border_color, theme },
+  });
+  if (!access.isPassed) {
+    return;
+  }
+
   // The second argument is a per-user PAT, which is backed by Postgres
   // upstream. We don't have that, so core falls back to the PAT_n pool.
   const { content } = await handler(req.query, null);
 
-  res.setHeader("Content-Type", "image/svg+xml");
   res.send(content);
 };

--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -1,9 +1,8 @@
-import { topLangs } from "@stats-organization/github-readme-stats-core";
+import { pin, topLangs } from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
 import { fromCore } from "./core.js";
 import { handler as gistHandler } from "../api/gist.js";
 import { handler as indexHandler } from "../api/index.js";
-import { handler as pinHandler } from "../api/pin.js";
 import wakatimeHandler from "../api/wakatime.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
 import { handler as statusUpHandler } from "../api/status/up.js";
@@ -57,9 +56,9 @@ export default {
     } else if (pathname === "/api/gist") {
       await gistHandler(req, res, env);
     } else if (pathname === "/api/pin") {
-      await pinHandler(req, res, env);
+      await fromCore(pin, "username", req, res, env);
     } else if (pathname === "/api/top-langs") {
-      await fromCore(topLangs, req, res, env);
+      await fromCore(topLangs, "username", req, res, env);
     } else if (pathname === "/api/wakatime") {
       await wakatimeHandler(req, res, env);
     } else if (pathname === "/api/status/pat-info") {


### PR DESCRIPTION
Second endpoint of stage 4 in #826, plus a fix for a regression from #828.

### Regression
All five legacy card endpoints call `guardAccess` (whitelist + blacklist), but `fromCore` did not — so #828 silently disabled it for `/api/top-langs`. Confirmed in production: `/api/top-langs?username=renovate-bot` served a real card while `/api` and `/api/pin` correctly refused.

Core has no equivalent by design: upstream keeps access control in `apps/backend`, not in the card package. So the guard now runs in `fromCore` before dispatch, keyed by access type (`username` / `gist` / `wakatime`).

This also reorders the plan — stage 5 listed `guardAccess` as something to port *after* stage 4, but it has to exist before any endpoint migrates.

### Verified under `workerd`
- `/api/pin?username=renovate-bot&repo=x` → blacklisted card, `image/svg+xml`, `max-age=600`
- `/api/pin?username=<user>` → `Missing params \"repo\"`
- `/api/pin?username=<user>&repo=<repo>` → 200 through core
- `/api/top-langs?username=renovate-bot` → blocked again
- Legacy `/api`, `/api/gist` unaffected
- Bundle 558.63 KiB / **135.48 KiB gzipped**; `eslint --max-warnings 0` clean

Real-output parity to be checked against production via the `pr-<n>` preview URL before merge.

### Note
Core's pin accepts `card_width`, `show`, `show_icons`, `number_format`, `text_bold`, `line_height` and `browser_rendering`, which the fork's handler did not. It drops `cache_seconds`, already inert on Workers since `index.js` overwrites `Cache-Control`.

Refs #826