### PR TITLE
feat(cloudflare): serve /api/pin from upstream core (migration stage 4)

### DIFF
--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -1,9 +1,8 @@
-import { topLangs } from "@stats-organization/github-readme-stats-core";
+import { pin, topLangs } from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
 import { fromCore } from "./core.js";
 import { handler as gistHandler } from "../api/gist.js";
 import { handler as indexHandler } from "../api/index.js";
-import { handler as pinHandler } from "../api/pin.js";
 import wakatimeHandler from "../api/wakatime.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
 import { handler as statusUpHandler } from "../api/status/up.js";
@@ -57,7 +56,7 @@ export default {
     } else if (pathname === "/api/gist") {
       await gistHandler(req, res, env);
     } else if (pathname === "/api/pin") {
-      await pinHandler(req, res, env);
+      await fromCore(pin, req, res, env);
     } else if (pathname === "/api/top-langs") {
       await fromCore(topLangs, req, res, env);
     } else if (pathname === "/api/wakatime") {


### PR DESCRIPTION
Second endpoint of the stage 4 cutover in #826. Same pattern as #828 — one line in the `if/else` chain.

### Verified under `workerd`
- `/api/pin?username=<user>&repo=<repo>` → 200, `image/svg+xml`, `Cache-Control: max-age=600`, `X-Robots-Tag`
- `/api/pin?username=<user>` → core's `Missing params \"repo\"`
- `/api`, `/api/gist`, `/api/status/up` unaffected; `/nope` still 404
- Bundle 558.21 KiB / **135.41 KiB gzipped**; `eslint --max-warnings 0` clean

Real-output parity against production to be checked via the `pr-<n>` preview URL before merge.

### Note
Core's pin accepts `card_width`, `show`, `show_icons`, `number_format`, `text_bold`, `line_height` and `browser_rendering`, which the fork's handler did not. It drops `cache_seconds`, already inert on Workers since `index.js` overwrites `Cache-Control`.

Refs #826