### PR TITLE
feat(cloudflare): serve /api/gist from upstream core (migration stage 4)

### DIFF
--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -1,7 +1,10 @@
-import { pin, topLangs } from "@stats-organization/github-readme-stats-core";
+import {
+  gist,
+  pin,
+  topLangs,
+} from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
 import { fromCore } from "./core.js";
-import { handler as gistHandler } from "../api/gist.js";
 import { handler as indexHandler } from "../api/index.js";
 import wakatimeHandler from "../api/wakatime.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
@@ -54,7 +57,7 @@ export default {
     if (pathname === "/api") {
       await indexHandler(req, res, env);
     } else if (pathname === "/api/gist") {
-      await gistHandler(req, res, env);
+      await fromCore(gist, req, res, env);
     } else if (pathname === "/api/pin") {
       await fromCore(pin, req, res, env);
     } else if (pathname === "/api/top-langs") {


### PR DESCRIPTION
Third endpoint of the stage 4 cutover in #826. Same pattern as #828 and #831.

### Verified under `workerd`
- `/api/gist?id=<id>` → 200, `image/svg+xml`, `Cache-Control: max-age=600`, `X-Robots-Tag`
- `/api/gist` → core's `Missing params \"id\"`
- `/api`, `/api/wakatime`, `/api/status/up` unaffected; `/nope` still 404
- Bundle 572.62 KiB / **142.76 KiB gzipped**; `eslint --max-warnings 0` clean

Parity against upstream's own deployment to be checked via the `pr-<n>` preview URL before merge, as in #831.

### Note
Core's gist is a near-exact param match: it adds `browser_rendering` and drops `cache_seconds`, which is already inert on Workers since `index.js` overwrites `Cache-Control`.

Refs #826