### PR TITLE
feat(cloudflare): serve /api/wakatime from upstream core (migration stage 4)

### DIFF
--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -2,11 +2,11 @@ import {
   gist,
   pin,
   topLangs,
+  wakatime,
 } from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
 import { fromCore } from "./core.js";
 import { handler as indexHandler } from "../api/index.js";
-import wakatimeHandler from "../api/wakatime.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
 import { handler as statusUpHandler } from "../api/status/up.js";
 
@@ -63,7 +63,7 @@ export default {
     } else if (pathname === "/api/top-langs") {
       await fromCore(topLangs, req, res, env);
     } else if (pathname === "/api/wakatime") {
-      await wakatimeHandler(req, res, env);
+      await fromCore(wakatime, req, res, env);
     } else if (pathname === "/api/status/pat-info") {
       await statusPatInfoHandler(req, res, env);
     } else if (pathname === "/api/status/up") {


### PR DESCRIPTION
Fourth endpoint of the stage 4 cutover in #826. Same pattern as #828, #831 and #832.

Wakatime needs no PAT, so this was verified against real data locally rather than only via preview.

### Verified under `workerd`, real calls to wakatime.com
| username | core vs prod legacy | core vs upstream deployment |
| --- | --- | --- |
| `anuraghazra` | **byte-identical** (2798 B) | **byte-identical** |
| `harryzcy` | differs by 11 B | **byte-identical** |

The 11-byte difference is only the known error-card changes — issue link `tiny.one/readme-stats` → `tinyurl.com/github-stats`, and `'…'` → `&#39;…&#39;`. No rendering difference, so unlike #832 this is a visually identical swap.

Also the first endpoint to exercise the axios fetch adapter against a non-GitHub host.

- Missing `username` → core's `Missing params \"username\"`
- Bundle 579.16 KiB / **141.71 KiB gzipped**; `eslint --max-warnings 0` clean

### Note
Params match the fork's exactly, minus `cache_seconds` — already inert on Workers since `index.js` overwrites `Cache-Control`.

Refs #826