### PR TITLE
fix(cloudflare): parse query string like upstream does

### DIFF
--- a/cloudflare/adapter.js
+++ b/cloudflare/adapter.js
@@ -7,15 +7,10 @@ export class RequestAdapter {
   constructor(request) {
     this.request = request;
 
-    const url = new URL(request.url);
-    const queryString = url.search.slice(1).split("&");
-
-    queryString.forEach((item) => {
-      const kv = item.split("=");
-      if (kv[0]) {
-        this.params[kv[0]] = kv[1] || true;
-      }
-    });
+    // Matches how upstream's express/vercel deployment parses the query
+    // string, so core handlers see identical input: percent-decoded values,
+    // and a valueless parameter as "" rather than a boolean.
+    this.params = Object.fromEntries(new URL(request.url).searchParams);
   }
 
   /**


### PR DESCRIPTION
Found while migrating `/api` (#826). `RequestAdapter` hand-parsed the query string, so core handlers received different input here than they do on upstream's deployment.

| input | before | now (= upstream) |
| --- | --- | --- |
| `custom_title=Hello%20World` | `Hello%20World` | `Hello World` |
| `title_color=%23ff0000` | `%23ff0000` | `#ff0000` |
| `?hide_border` | `true` → border hidden | `""` → border shown |
| `a=b=c` | `b` | `b=c` |

### Verified
`/api/wakatime` is byte-identical to `github-stats-extended.vercel.app` across encoded titles, `%2B`, bare flags, `hide_border=true`, prefixed hex, bare hex and gradients. It's the only endpoint testable locally without a real PAT; the rest are covered by the preview deploy.

### Behaviour change to be aware of
`?hide_border` with no value now shows the border, matching upstream. `?hide_border=true` is unaffected.

### Not fixed here, by design
Core rejects `#`-prefixed hex (`isValidColorInput` accepts bare hex or gradients only), so `title_color=%23ff0000` returns an error card. **Upstream returns the same error**, so this is faithful. Legacy silently ignored invalid colours and rendered defaults — the value was never applied either way, it's just explicit now.

Refs #826