### PR TITLE
feat(cloudflare): serve /api from upstream core (migration stage 4)

### DIFF
--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -1,4 +1,5 @@
 import {
+  api,
   gist,
   pin,
   topLangs,
@@ -6,7 +7,6 @@ import {
 } from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
 import { fromCore } from "./core.js";
-import { handler as indexHandler } from "../api/index.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
 import { handler as statusUpHandler } from "../api/status/up.js";
 
@@ -55,7 +55,7 @@ export default {
     }
 
     if (pathname === "/api") {
-      await indexHandler(req, res, env);
+      await fromCore(api, req, res, env);
     } else if (pathname === "/api/gist") {
       await fromCore(gist, req, res, env);
     } else if (pathname === "/api/pin") {


### PR DESCRIPTION
Final endpoint of the stage 4 cutover in #826. Rebased on #834 so it lands with upstream-matching query parsing already in place.

### Params
Core covers every param the fork's handler read, including `ring_color`, and adds `owner`, `repo` and `role`. It drops only `cache_seconds`, already inert on Workers since `index.js` overwrites `Cache-Control`.

### Verified under `workerd`
- 200, `image/svg+xml`, `Cache-Control: max-age=600`, `X-Robots-Tag`
- Missing `username` → `Missing params \"username\"`; bad `locale` → `Language not found`; invalid colour → `Invalid color input for parameter …`
- `/api/status/up`, `/api/status/pat-info`, `/`, `/robots.txt` unaffected; `/nope` still 404
- `eslint --max-warnings 0` clean

### Bundle
**579.16 → 473.55 KiB (141.71 → 113.11 KiB gzipped)** — with all five card endpoints on core, most of the legacy `src/` tree is unreachable. Only `api/status/*` still imports from it.

### Behaviour change
Invalid colours now produce an error card instead of being silently ignored — e.g. `title_color=%23ff0000`. Upstream errors identically; the value was never applied either way.

Real-data parity against `github-stats-extended.vercel.app` to be checked via the `pr-<n>` preview before merge, as `/api` needs a PAT.

Refs #826