### PR TITLE
refactor(status): get PATs from core config

### DIFF
--- a/api/status/pat-info.js
+++ b/api/status/pat-info.js
@@ -7,10 +7,12 @@
  * @description This function is currently rate limited to 1 request per 5 minutes.
  */
 
-import process from "node:process";
-import { request } from "../../src/common/http.js";
-import { logger } from "../../src/common/log.js";
-import { dateDiff } from "../../src/common/ops.js";
+import {
+  dateDiff,
+  getConfig,
+  logger,
+  request,
+} from "@stats-organization/github-readme-stats-core";
 
 export const RATE_LIMIT_SECONDS = 60 * 5; // 1 request per 5 minutes
 
@@ -19,10 +21,9 @@ export const RATE_LIMIT_SECONDS = 60 * 5; // 1 request per 5 minutes
  *
  * @param {any} variables Fetcher variables.
  * @param {string} token GitHub token.
- * @param {boolean} useFetch Use fetch instead of axios.
  * @returns {Promise<import('axios').AxiosResponse>} The response.
  */
-const uptimeFetcher = (variables, token, useFetch) => {
+const uptimeFetcher = (variables, token) => {
   return request(
     {
       query: `
@@ -37,12 +38,11 @@ const uptimeFetcher = (variables, token, useFetch) => {
     {
       Authorization: `bearer ${token}`,
     },
-    useFetch,
   );
 };
 
-const getAllPATs = (env) => {
-  return Object.keys(env).filter((key) => /PAT_\d*$/.exec(key));
+const getAllPATs = () => {
+  return getConfig().pats;
 };
 
 /**
@@ -55,17 +55,16 @@ const getAllPATs = (env) => {
  *
  * @param {Fetcher} fetcher The fetcher function.
  * @param {any} variables Fetcher variables.
- * @param {{[key: string]: string}} env The environment variables.
  * @returns {Promise<PATInfo>} The response.
  */
-const getPATInfo = async (fetcher, variables, env) => {
+const getPATInfo = async (fetcher, variables) => {
   /** @type {Record<string, any>} */
   const details = {};
-  const PATs = getAllPATs(env);
+  const PATs = getAllPATs();
 
   for (const pat of PATs) {
     try {
-      const response = await fetcher(variables, env[pat]);
+      const response = await fetcher(variables, pat.value);
       const errors = response.data.errors;
       const hasErrors = Boolean(errors);
       const errorType = errors?.[0]?.type;
@@ -75,7 +74,7 @@ const getPATInfo = async (fetcher, variables, env) => {
 
       // Store PATs with errors.
       if (hasErrors && errorType !== "RATE_LIMITED") {
-        details[pat] = {
+        details[pat.name] = {
           status: "error",
           error: {
             type: errors[0].type,
@@ -86,13 +85,13 @@ const getPATInfo = async (fetcher, variables, env) => {
       } else if (isRateLimited) {
         const date1 = new Date();
         const date2 = new Date(response.data?.data?.rateLimit?.resetAt);
-        details[pat] = {
+        details[pat.name] = {
           status: "exhausted",
           remaining: 0,
           resetIn: dateDiff(date2, date1) + " minutes",
         };
       } else {
-        details[pat] = {
+        details[pat.name] = {
           status: "valid",
           remaining: response.data.data.rateLimit.remaining,
         };
@@ -101,11 +100,11 @@ const getPATInfo = async (fetcher, variables, env) => {
       // Store the PAT if it is expired.
       const errorMessage = err.response?.data?.message?.toLowerCase();
       if (errorMessage === "bad credentials") {
-        details[pat] = {
+        details[pat.name] = {
           status: "expired",
         };
       } else if (errorMessage === "sorry. your account was suspended.") {
-        details[pat] = {
+        details[pat.name] = {
           status: "suspended",
         };
       } else {
@@ -140,14 +139,13 @@ const getPATInfo = async (fetcher, variables, env) => {
  *
  * @param {any} _ The request.
  * @param {any} res The response.
- * @param {{[key: string]: string}} env The environment variables.
  * @returns {Promise<void>} The response.
  */
-export const handler = async (_, res, env) => {
+export const handler = async (_, res) => {
   res.setHeader("Content-Type", "application/json");
   try {
     // Add header to prevent abuse.
-    const PATsInfo = await getPATInfo(uptimeFetcher, {}, env);
+    const PATsInfo = await getPATInfo(uptimeFetcher, {});
     if (PATsInfo) {
       res.setHeader(
         "Cache-Control",
@@ -163,4 +161,4 @@ export const handler = async (_, res, env) => {
   }
 };
 
-export default async (req, res) => handler(req, res, process.env);
+export default async (req, res) => handler(req, res);

--- a/cloudflare/core.js
+++ b/cloudflare/core.js
@@ -10,6 +10,22 @@ axios.defaults.adapter = "fetch";
 let configured = false;
 
 /**
+ * Make core's config -- the PAT pool in particular -- available to any handler
+ * that needs it. Core loads it from `process.env` at import time, which is
+ * empty here, so it has to be reloaded from the Worker's env bindings.
+ *
+ * @param {object} env Environment variables.
+ * @returns {void}
+ */
+export const ensureConfig = (env) => {
+  if (!configured) {
+    // env is constant for the lifetime of a deployment, so load it once.
+    loadConfigFromEnv(env);
+    configured = true;
+  }
+};
+
+/**
  * Run an upstream core card handler and write its result into the response
  * adapter, so the shared header handling in index.js still applies.
  *
@@ -20,11 +36,7 @@ let configured = false;
  * @returns {Promise<void>}
  */
 export const fromCore = async (handler, req, res, env) => {
-  if (!configured) {
-    // env is constant for the lifetime of a deployment, so load it once.
-    loadConfigFromEnv(env);
-    configured = true;
-  }
+  ensureConfig(env);
 
   // The second argument is a per-user PAT, which is backed by Postgres
   // upstream. We don't have that, so core falls back to the PAT_n pool.

--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -6,13 +6,14 @@ import {
   wakatime,
 } from "@stats-organization/github-readme-stats-core";
 import { RequestAdapter, ResponseAdapter } from "./adapter.js";
-import { fromCore } from "./core.js";
+import { ensureConfig, fromCore } from "./core.js";
 import { handler as statusPatInfoHandler } from "../api/status/pat-info.js";
 import { handler as statusUpHandler } from "../api/status/up.js";
 
 export default {
   async fetch(request, env) {
     env.IS_CLOUDFLARE = "true"; // used to detect if running on Cloudflare
+    ensureConfig(env);
 
     const req = new RequestAdapter(request);
     const res = new ResponseAdapter();
@@ -65,7 +66,7 @@ export default {
     } else if (pathname === "/api/wakatime") {
       await fromCore(wakatime, req, res, env);
     } else if (pathname === "/api/status/pat-info") {
-      await statusPatInfoHandler(req, res, env);
+      await statusPatInfoHandler(req, res);
     } else if (pathname === "/api/status/up") {
       await statusUpHandler(req, res, env);
     } else {

--- a/tests/pat-info.test.js
+++ b/tests/pat-info.test.js
@@ -15,6 +15,7 @@ import {
 } from "@jest/globals";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
+import { loadConfigFromEnv } from "@stats-organization/github-readme-stats-core";
 import patInfo, { RATE_LIMIT_SECONDS } from "../api/status/pat-info.js";
 
 const mock = new MockAdapter(axios);
@@ -78,6 +79,10 @@ describe("Test /api/status/pat-info", () => {
     process.env.PAT_2 = "testPAT2";
     process.env.PAT_3 = "testPAT3";
     process.env.PAT_4 = "testPAT4";
+
+    // Core snapshots its config when it is first imported, which happens
+    // before this runs, so it has to be reloaded from the patched env.
+    loadConfigFromEnv(process.env);
   });
 
   it("should return only 'validPATs' if all PATs are valid", async () => {


### PR DESCRIPTION
Stage 5 of #826 — first of the two status endpoints off `src/`.

Ported in place rather than copied into `cloudflare/`, so the Vercel function keeps working: core's config falls back to `process.env` when no env is passed.

### Changes
- `api/status/pat-info.js`: imports `dateDiff`, `getConfig`, `logger`, `request` from core; `getAllPATs(env)` → `getConfig().pats`; `details[pat]` → `details[pat.name]`; drops the dead `useFetch` argument, `node:process`, and stale JSDoc. Now closely matches upstream's `apps/backend/api-renamed/status/pat-info.js`
- `cloudflare/core.js`: `ensureConfig(env)` extracted from `fromCore`
- `cloudflare/index.js`: calls `ensureConfig(env)` in `fetch()`

The hoist is required, not incidental — `getConfig()` returns nothing until `loadConfigFromEnv(env)` runs, and status endpoints don't go through `fromCore`. Without it, a status request arriving first in a fresh isolate would report no PATs.

### Verified under `workerd` with two fake PATs
```json
"expiredPATs": ["PAT_1", "PAT_2"]
```
Both discovered by name and classified from GitHub's "bad credentials" — empty arrays would indicate config never loaded. Other routes unaffected; bundle 473.32 KiB / **113.10 KiB gzipped**.

Refs #826