### PR TITLE
refactor(status): serve up endpoint from core, fix json responses

### DIFF
--- a/api/status/up.js
+++ b/api/status/up.js
@@ -7,9 +7,11 @@
  * @description This function is currently rate limited to 1 request per 5 minutes.
  */
 
-import { request } from "../../src/common/http.js";
-import retryer from "../../src/common/retryer.js";
-import { logger } from "../../src/common/log.js";
+import {
+  logger,
+  request,
+  retryer,
+} from "@stats-organization/github-readme-stats-core";
 
 export const RATE_LIMIT_SECONDS = 60 * 5; // 1 request per 5 minutes
 
@@ -18,10 +20,9 @@ export const RATE_LIMIT_SECONDS = 60 * 5; // 1 request per 5 minutes
  *
  * @param {any} variables Fetcher variables.
  * @param {string} token GitHub token.
- * @param {boolean=} useFetch Use fetch instead of axios.
  * @returns {Promise<import('axios').AxiosResponse>} The response.
  */
-const uptimeFetcher = (variables, token, useFetch) => {
+const uptimeFetcher = (variables, token) => {
   return request(
     {
       query: `
@@ -36,7 +37,6 @@ const uptimeFetcher = (variables, token, useFetch) => {
     {
       Authorization: `bearer ${token}`,
     },
-    useFetch,
   );
 };
 
@@ -78,10 +78,9 @@ const shieldsUptimeBadge = (up) => {
  *
  * @param {any} req The request.
  * @param {any} res The response.
- * @param {{[key: string]: string}} env The environment variables.
  * @returns {Promise<void>} Nothing.
  */
-export const handler = async (req, res, env) => {
+export const handler = async (req, res) => {
   let { type } = req.query;
   type = type ? type.toLowerCase() : "boolean";
 
@@ -90,7 +89,7 @@ export const handler = async (req, res, env) => {
   try {
     let PATsValid = true;
     try {
-      await retryer(uptimeFetcher, {}, env);
+      await retryer(uptimeFetcher, {});
     } catch (err) {
       // Resolve eslint no-unused-vars
       err;
@@ -126,4 +125,4 @@ export const handler = async (req, res, env) => {
   }
 };
 
-export default async (req, res) => handler(req, res, process.env);
+export default async (req, res) => handler(req, res);

--- a/cloudflare/adapter.js
+++ b/cloudflare/adapter.js
@@ -36,11 +36,20 @@ export class ResponseAdapter {
   }
 
   /**
-   * @param {string} body response body
+   * Mirrors the express-like `send` upstream's router provides: objects are
+   * serialised as JSON, anything else is coerced to a string.
+   *
+   * @param {any} body response body
    * @returns {void}
    */
   send(body) {
-    this.body = body;
+    if (typeof body === "object" && body !== null) {
+      this.headers["Content-Type"] = "application/json";
+      this.body = JSON.stringify(body);
+      return;
+    }
+
+    this.body = typeof body === "string" ? body : String(body);
   }
 
   /**

--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -68,13 +68,14 @@ export default {
     } else if (pathname === "/api/status/pat-info") {
       await statusPatInfoHandler(req, res);
     } else if (pathname === "/api/status/up") {
-      await statusUpHandler(req, res, env);
+      await statusUpHandler(req, res);
     } else {
       return new Response("not found", { status: 404 });
     }
-    if (pathname === "/api/status/up") {
-      res.setHeader("Cache-Control", "max-age=0"); // no cache
-    } else {
+
+    // The status endpoints pick their own cache lifetime; only fall back to
+    // the default for handlers that didn't set one.
+    if (!res.headers["Cache-Control"]) {
       res.setHeader("Cache-Control", "max-age=600"); // 10 min
     }
 

--- a/tests/status.up.test.js
+++ b/tests/status.up.test.js
@@ -2,9 +2,17 @@
  * @file Tests for the status/up cloud function.
  */
 
-import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
+import { loadConfigFromEnv } from "@stats-organization/github-readme-stats-core";
 import up, { RATE_LIMIT_SECONDS } from "../api/status/up.js";
 
 const mock = new MockAdapter(axios);
@@ -59,6 +67,15 @@ afterEach(() => {
 });
 
 describe("Test /api/status/up", () => {
+  beforeAll(() => {
+    // The retryer rotates through core's PAT pool and fails outright when it
+    // is empty. Core reads the pool from process.env when it is first
+    // imported, which has already happened, so reload it from the patched env.
+    process.env.PAT_1 = "dummyPAT1";
+    process.env.PAT_2 = "dummyPAT2";
+    loadConfigFromEnv(process.env);
+  });
+
   it("should return `true` if request was successful", async () => {
     mock.onPost("https://api.github.com/graphql").replyOnce(200, successData);
 


### PR DESCRIPTION
Stage 5 of #826. Completes the status port and fixes two live bugs found along the way.

### 1. `status/up` ported off `src/`
Imports `logger`, `request`, `retryer` from core; drops `env` and the dead `useFetch` argument. **The Worker no longer imports `src/` at all.**

### 2. `[object Object]` fixed
`ResponseAdapter.send()` coerced objects with `String()`:

| | before | after |
| --- | --- | --- |
| `?type=json` | `[object Object]` | `{"up":true}` |
| `?type=shields` | `[object Object]` | `{"schemaVersion":1,…}` |

Now serialises objects as JSON and sets the JSON content type, as upstream's `router.js` does.

### 3. Handler cache headers were being discarded
`index.js` overwrote `Cache-Control` after the handler ran, so `pat-info` was cached for 10 minutes despite asking for `max-age=0, s-maxage=300`. The default now applies only when a handler hasn't set one — card endpoints are unchanged at `max-age=600`.

### Tests
`status.up` needed a PAT stub: core's retryer throws on an empty pool, where the old fork retryer had a `NODE_ENV === "test"` escape hatch. Stubbed in that file's own `beforeAll` rather than a global setup file, matching `pat-info.test.js`.

18/18 on both status suites; full suite 241 passed, 1 pre-existing failure (`calculateRank`, Node 26 float, green on CI's Node 22). Bundle 469.33 KiB / **112.18 KiB gzipped**.

Refs #826