### PR TITLE
feat(cloudflare): restore whitelist/blacklist guard

### DIFF
--- a/cloudflare/core.js
+++ b/cloudflare/core.js
@@ -1,5 +1,9 @@
 import axios from "axios";
-import { loadConfigFromEnv } from "@stats-organization/github-readme-stats-core";
+import {
+  getConfig,
+  loadConfigFromEnv,
+  renderError,
+} from "@stats-organization/github-readme-stats-core";
 
 // Axios picks fetch here anyway -- http and xhr are unavailable under
 // workerd -- so this only makes the choice explicit.
@@ -10,6 +14,13 @@ axios.defaults.adapter = "fetch";
 // Kept as a bare repo reference: the full URL overflows the fixed-width card.
 const CORE_ISSUE_URL = "https://tinyurl.com/github-stats";
 const ISSUE_REF = "harryzcy/github-readme-stats";
+
+// Which query parameter carries the guarded identifier, per access type.
+const ID_PARAM = {
+  username: "username",
+  gist: "id",
+  wakatime: "username",
+};
 
 let configured = false;
 
@@ -30,22 +41,97 @@ export const ensureConfig = (env) => {
 };
 
 /**
+ * @param {string=} value Comma-separated list.
+ * @returns {string[]} Trimmed, non-empty entries.
+ */
+const parseList = (value) => {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+};
+
+/**
+ * Refuse a request when the identifier is not whitelisted, or is blacklisted.
+ *
+ * Core has no access control -- upstream keeps it in its backend, since which
+ * identifiers an instance serves is deployment policy rather than card logic
+ * -- so it lives here. Whitelists come from core's config (`WHITELIST` and
+ * `GIST_WHITELIST`); the blacklist comes from `BLACKLIST`.
+ *
+ * @param {"username"|"gist"|"wakatime"} type Access type.
+ * @param {import("./adapter.js").RequestAdapter} req Request adapter.
+ * @param {object} env Environment variables.
+ * @returns {string|null} An error card, or null when access is allowed.
+ */
+const guardAccess = (type, req, env) => {
+  const { title_color, text_color, bg_color, border_color, theme } = req.query;
+  const renderOptions = {
+    title_color,
+    text_color,
+    bg_color,
+    border_color,
+    theme,
+    show_repo_link: false,
+  };
+
+  const id = req.query[ID_PARAM[type]];
+  const { whitelist, gistWhitelist } = getConfig();
+  const allowed = type === "gist" ? gistWhitelist : whitelist;
+
+  if (Array.isArray(allowed) && !allowed.includes(id)) {
+    return renderError({
+      message:
+        type === "gist"
+          ? "This gist ID is not whitelisted"
+          : "This username is not whitelisted",
+      secondaryMessage: "Please deploy your own instance",
+      renderOptions,
+    });
+  }
+
+  // A whitelist already restricts access, so the blacklist only applies when
+  // there isn't one. Gist IDs and wakatime users are not blacklisted.
+  if (
+    type === "username" &&
+    allowed === undefined &&
+    parseList(env.BLACKLIST).includes(id)
+  ) {
+    return renderError({
+      message: "This username is blacklisted",
+      secondaryMessage: "Please deploy your own instance",
+      renderOptions,
+    });
+  }
+
+  return null;
+};
+
+/**
  * Run an upstream core card handler and write its result into the response
  * adapter, so the shared header handling in index.js still applies.
  *
  * @param {Function} handler Core card handler.
+ * @param {"username"|"gist"|"wakatime"} type Access type to guard on.
  * @param {import("./adapter.js").RequestAdapter} req Request adapter.
  * @param {import("./adapter.js").ResponseAdapter} res Response adapter.
  * @param {object} env Environment variables.
  * @returns {Promise<void>}
  */
-export const fromCore = async (handler, req, res, env) => {
+export const fromCore = async (handler, type, req, res, env) => {
   ensureConfig(env);
+
+  res.setHeader("Content-Type", "image/svg+xml");
+
+  const refused = guardAccess(type, req, env);
+  if (refused) {
+    res.send(refused.replace(CORE_ISSUE_URL, ISSUE_REF));
+    return;
+  }
 
   // The second argument is a per-user PAT, which is backed by Postgres
   // upstream. We don't have that, so core falls back to the PAT_n pool.
   const { content } = await handler(req.query, null);
 
-  res.setHeader("Content-Type", "image/svg+xml");
   res.send(content.replace(CORE_ISSUE_URL, ISSUE_REF));
 };

--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -56,15 +56,15 @@ export default {
     }
 
     if (pathname === "/api") {
-      await fromCore(api, req, res, env);
+      await fromCore(api, "username", req, res, env);
     } else if (pathname === "/api/gist") {
-      await fromCore(gist, req, res, env);
+      await fromCore(gist, "gist", req, res, env);
     } else if (pathname === "/api/pin") {
-      await fromCore(pin, req, res, env);
+      await fromCore(pin, "username", req, res, env);
     } else if (pathname === "/api/top-langs") {
-      await fromCore(topLangs, req, res, env);
+      await fromCore(topLangs, "username", req, res, env);
     } else if (pathname === "/api/wakatime") {
-      await fromCore(wakatime, req, res, env);
+      await fromCore(wakatime, "wakatime", req, res, env);
     } else if (pathname === "/api/status/pat-info") {
       await statusPatInfoHandler(req, res);
     } else if (pathname === "/api/status/up") {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,9 +4,9 @@ compatibility_date = "2025-05-05"
 compatibility_flags = [ "nodejs_compat" ]
 
 [vars]
-# Usernames refused by the access guard. Mostly readme placeholders people
-# paste without editing, which would otherwise spend GitHub API quota.
-BLACKLIST = "renovate-bot,technote-space,sw-yx,YourUsername,[YourUsername]"
+# Usernames refused by the access guard. High-volume accounts, inherited from
+# upstream, which blocked them in 2020 to shed load from its public instance.
+BLACKLIST = "renovate-bot,technote-space,sw-yx"
 
 [observability]
 [observability.logs]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,9 @@ compatibility_date = "2025-05-05"
 compatibility_flags = [ "nodejs_compat" ]
 
 [vars]
+# Usernames refused by the access guard. Mostly readme placeholders people
+# paste without editing, which would otherwise spend GitHub API quota.
+BLACKLIST = "renovate-bot,technote-space,sw-yx,YourUsername,[YourUsername]"
 
 [observability]
 [observability.logs]


### PR DESCRIPTION
Stage 5 of #826. Migrating the card endpoints to core silently dropped access control — core has none by design, since which identifiers an instance serves is deployment policy rather than card logic.

Reimplemented in `cloudflare/core.js` rather than importing `src/common/access.js`, which would undo the `src/` decoupling finished in #837. No Postgres.

| list | source |
| --- | --- |
| whitelist | core's `getConfig().whitelist` ← `WHITELIST` |
| gist whitelist | core's `getConfig().gistWhitelist` ← `GIST_WHITELIST` |
| blacklist | new `BLACKLIST` var, seeded in `wrangler.toml` |

Upstream still hardcodes five entries in `apps/backend/src/common/blacklist.js`. We keep the three real accounts and drop the two readme placeholders:

```
BLACKLIST = "renovate-bot,technote-space,sw-yx"
```

`YourUsername` and `[YourUsername]` therefore reach core now. `[YourUsername]` fails at GitHub on the brackets, and `YourUsername` is a valid username shape, so those requests spend an API call where they previously did not — an error card either way, so nothing user-visible changes.

Making it a var rather than a source file also removes the last reason to keep `src/common/blacklist.js`, and lets the list change without a code deploy.

### Verified under `workerd`
- Blacklist refuses `renovate-bot`, `sw-yx` and `technote-space` on `/api`, `/api/pin`, `/api/top-langs`; does **not** apply to gist IDs or wakatime, matching the original logic
- Whitelist refuses non-listed usernames and gist IDs, allows listed ones
- Whitelist takes precedence: with one set, the blacklist is skipped
- Refusal cards reuse core's `renderError` and go through the same issue-link rewrite as #838

Also confirmed on the `pr-841` preview with real PATs: allowed users render real cards (`/api?username=harryzcy`, 5321 B), `YourUsername` renders, and `/api/wakatime?username=renovate-bot` reaches core.

Tests 241 passed, 1 pre-existing (`calculateRank`, Node 26 float). Bundle 470.86 KiB / **112.59 KiB gzipped**.

Refs #826
