### PR TITLE
docs: point og:url at this instance's vercel domain

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -15,7 +15,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content="https://github-stats-extended.vercel.app/frontend"
+      content="https://github-readme-stats-vercel.zcy.dev/frontend"
     />
     <meta property="og:title" content="GitHub Stats Extended" />
     <meta


### PR DESCRIPTION
Follow-up to #855, which imported `apps/frontend` but kept upstream's canonical URL in `index.html`:

```diff
-      content="https://github-stats-extended.vercel.app/frontend"
+      content="https://github-readme-stats-vercel.zcy.dev/frontend"
```

Affects social-preview metadata only. Brings `apps/frontend` to 4 link swaps against upstream, all deliberate; the two comments citing upstream PR discussions stay pointing upstream.

Refs #842