### PR TITLE
build: adopt upstream's dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,27 +5,79 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "build(deps)"
       prefix-development: "build(deps-dev)"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-*"
+          - "@types/react"
+          - "@types/react-dom"
+      redux:
+        patterns:
+          - "redux"
+          - "@reduxjs/*"
+          - "react-redux"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "daisyui"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-*"
+          - "typescript-eslint"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@types/*"
+      playwright:
+        patterns:
+          - "@playwright/*"
+      axios:
+        patterns:
+          - "axios"
+          - "axios-*"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "ci(deps)"
       prefix-development: "ci(deps-dev)"
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for Devcontainers
   - package-ecosystem: devcontainers
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: daily
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "build(deps)"
       prefix-development: "build(deps-dev)"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Our dependabot config predates the monorepo. The pinned dependency surface grew from ~15 to **43** across four manifests when `packages/core`, `apps/backend` and `apps/frontend` landed, and the old config had no grouping and a limit of 10.

Adopted upstream's verbatim — `git diff upstream/master -- .github/dependabot.yml` is **0 lines**, so it will not conflict on future merges.

### pnpm workspaces are already tracked
Confirmed empirically: #851 is titled *"bump js-yaml … **in /packages/core**"*, so dependabot parses `pnpm-lock.yaml` and traverses the workspace globs from `directory: "/"`. Upstream depends on the same behaviour — their `react`/`vite`/`tailwind` groups only make sense because it reaches `apps/frontend`.

### What changes
9 groups now cover 26 of our 43 pinned deps:

| group | covers |
| --- | --- |
| react | 9 |
| eslint | 7 |
| tailwind | 3 |
| axios, redux | 2 each |
| vite, typescript, playwright | 1 each |

17 remain individual, including `wrangler`, `turbo`, `prettier` and `pg`. Also `@eslint-react/eslint-plugin`, which slips the `eslint-*` pattern because it is scoped as `@eslint-react/` — upstream has the same gap, so it is left alone rather than diverged from.

Limit goes 10 → 20.

### ⚠️ One thing to decide: the cooldown contradicts the stated policy
Upstream's config sets `cooldown: default-days: 7` on **all three ecosystems**, which holds every update back for a week. If the policy is to take dependency updates as fast as possible, that is the opposite of what is wanted, and it is a three-line deletion.

Keeping it means matching upstream exactly and never conflicting on this file. Removing it means faster updates and a small permanent divergence. Happy to drop it before merge — say which.

For what it is worth, we never adopted upstream's other delay, `minimumReleaseAge: 10080` in `pnpm-workspace.yaml`, so the cooldown is currently the only thing slowing updates down.

### Note on vendored manifests
With updates accepted as fast as possible, dependabot will keep bumping dependencies *inside* `packages/core`, `apps/backend` and `apps/frontend` — as #851 already does. Each merged bump makes those trees stop being byte-identical to upstream, so `git merge upstream/master` will conflict on `package.json` and `pnpm-lock.yaml`. That is the accepted trade for faster updates; noting it so the conflicts are expected rather than alarming.

Refs #842