### PR TITLE
ci: open a pr when upstream moves

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,142 @@
+name: Sync Upstream
+
+# Vendored packages/core, apps/backend and apps/frontend are byte-identical to
+# upstream, so dependabot cannot see them and nothing else notices when
+# upstream moves. This opens a PR with the merge, or files an issue when the
+# merge needs hands.
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC. Upstream merges most days, so daily would be noise.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  UPSTREAM: https://github.com/stats-organization/github-stats-extended.git
+  UPSTREAM_BRANCH: master
+  SYNC_BRANCH: sync/upstream
+
+jobs:
+  sync:
+    name: Merge upstream
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream "$UPSTREAM"
+          git fetch upstream "$UPSTREAM_BRANCH"
+
+      - name: Check whether upstream has moved
+        id: check
+        run: |
+          behind=$(git rev-list --count "HEAD..upstream/$UPSTREAM_BRANCH")
+          echo "behind=$behind" >> "$GITHUB_OUTPUT"
+          if [ "$behind" -eq 0 ]; then
+            echo "Already up to date with upstream." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "$behind commit(s) behind upstream." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Attempt the merge
+        id: merge
+        if: steps.check.outputs.behind != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$SYNC_BRANCH"
+
+          if git merge --no-edit "upstream/$UPSTREAM_BRANCH"; then
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+            # record the conflicting paths before throwing the attempt away
+            git diff --name-only --diff-filter=U > /tmp/conflicts.txt
+            git merge --abort
+          fi
+
+      - name: Open or update the pull request
+        if: steps.merge.outputs.clean == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git push --force-with-lease origin "$SYNC_BRANCH"
+
+          body=$(cat <<EOF
+          Merges ${{ steps.check.outputs.behind }} commit(s) from [upstream](https://github.com/stats-organization/github-stats-extended).
+
+          The merge applied cleanly. Before merging, check that the vendored trees still
+          match upstream and that our deliberate divergences survived:
+
+          \`\`\`bash
+          git diff upstream/master -- packages/core          # expect empty
+          git diff upstream/master -- apps/backend           # expect the vercel.json redirect
+          git diff upstream/master -- apps/frontend          # expect the link swaps and og:url
+          \`\`\`
+
+          Upstream changes can alter rendered output — a card's height and an icon colour
+          both moved in #832 — so compare a card against production before merging.
+
+          > Opened by the \`Sync Upstream\` workflow. Do **not** squash: squashing discards
+          > the second parent and resets the merge base, which is what #871 fixed.
+          EOF
+          )
+
+          if gh pr list --head "$SYNC_BRANCH" --state open --json number --jq 'length' | grep -qv '^0$'; then
+            gh pr edit "$SYNC_BRANCH" --body "$body"
+            echo "Updated the existing sync PR." >> "$GITHUB_STEP_SUMMARY"
+          else
+            gh pr create \
+              --base "${{ github.ref_name }}" \
+              --head "$SYNC_BRANCH" \
+              --title "chore: merge upstream ($(date -u +%Y-%m-%d))" \
+              --body "$body"
+            echo "Opened a sync PR." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Report a conflicting merge
+        if: steps.merge.outputs.clean == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          conflicts=$(sed 's/^/- `/; s/$/`/' /tmp/conflicts.txt)
+          title="Upstream merge needs manual resolution"
+          body=$(cat <<EOF
+          \`upstream/$UPSTREAM_BRANCH\` is ${{ steps.check.outputs.behind }} commit(s) ahead and the
+          merge does not apply cleanly, so no PR was opened.
+
+          Conflicting paths:
+
+          $conflicts
+
+          To resolve locally:
+
+          \`\`\`bash
+          git fetch upstream
+          git switch -c $SYNC_BRANCH
+          git merge upstream/$UPSTREAM_BRANCH
+          \`\`\`
+
+          Our deliberate divergences are listed under "Copy rule" in #842.
+
+          > Filed by the \`Sync Upstream\` workflow. It updates this issue rather than
+          > opening a new one each week.
+          EOF
+          )
+
+          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -7,8 +7,8 @@ name: Sync Upstream
 
 on:
   schedule:
-    # Mondays, 06:00 UTC. Upstream merges most days, so daily would be noise.
-    - cron: "0 6 * * 1"
+    # Fridays, 06:00 UTC. Upstream merges most days, so daily would be noise.
+    - cron: "0 6 * * 5"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #850.

Vendoring `packages/core` removed the only thing that told us upstream had released: dependabot cannot see an in-tree package. Since #875 reset the merge base, staying current is a `git merge upstream/master` — but only if someone notices upstream moved.

Weekly on Mondays, plus `workflow_dispatch`.

| upstream state | action |
| --- | --- |
| not ahead | nothing; noted in the run summary |
| ahead, merge clean | pushes `sync/upstream`, opens **or updates** one PR |
| ahead, merge conflicts | aborts, files or comments on **one** issue listing the conflicting paths |

A single branch and a single issue are reused rather than accumulating one per week, per the discussion in #850.

### Why it opens a PR rather than merging
Upstream changes can alter rendered output — #832 moved a card's height by 12px and changed an icon colour, purely from taking newer code. The value is in *noticing*, not in applying unattended. The PR body carries the verification steps:

```bash
git diff upstream/master -- packages/core     # expect empty
git diff upstream/master -- apps/backend      # expect the vercel.json redirect
git diff upstream/master -- apps/frontend     # expect the link swaps and og:url
```

…and a **do not squash** warning, since squashing discards the second parent and resets the merge base that #871 fixed.

### Verified locally
Both decision paths were exercised against the real repository:
- at today's HEAD: `behind=0` → skips the merge, opens nothing
- reset to `ce5e046a` (pre-#875): `behind=1501`, conflicts detected, would file the issue with the conflicting paths listed

### Known limitation
PRs created with `GITHUB_TOKEN` do not trigger other workflows — GitHub blocks that to prevent recursion. So a sync PR will not automatically get `Perform tests`, `Deploy` or `CodeQL`, and branch protection will hold it until checks are run, e.g. by pushing a commit to the branch.

Fixable with a PAT secret if that friction shows up; left on `GITHUB_TOKEN` for now since it needs no new secret.